### PR TITLE
Missing include file in CompiledSouffle.h (corrected)

### DIFF
--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <fstream>
 #include "AstTypes.h"
 #include "CompiledRamOptions.h"
 #include "CompiledRamRecord.h"
@@ -28,7 +29,6 @@
 
 #include <array>
 #include <cmath>
-#include <fstream>
 #include <iostream>
 #include <map>
 #include <regex>

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -26,6 +26,7 @@
 #include "SouffleInterface.h"
 #include "SymbolTable.h"
 
+#include <fstream>
 #include <array>
 #include <cmath>
 #include <iostream>

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -26,9 +26,9 @@
 #include "SouffleInterface.h"
 #include "SymbolTable.h"
 
-#include <fstream>
 #include <array>
 #include <cmath>
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <regex>


### PR DESCRIPTION
This is a correction to b-scholz  pull request #487.

C++ Interface breaks without the include.

Bernhard and I have been working on a new Python language interface using SWIG. SWIG permits also other languages (JAVA, CLISP, etc.). It seems that the generated C++ code of souffle requires fstream.h when compiled with the flag EMBEDDED_SYSTEM due to the new I/O system. The other alternative is to produce an include directive in the output in souffle (which is less desirable).

